### PR TITLE
Added .sblib to the list of supported extensions

### DIFF
--- a/grammars/smart-basic.cson
+++ b/grammars/smart-basic.cson
@@ -2,7 +2,8 @@
 'name': 'smartBASIC'
 
 'fileTypes': [
-    'sb'
+    'sb',
+    'sblib'
 ]
 
 'patterns': [{


### PR DESCRIPTION
Laird uses .sblib extension for its library source files written in
SMARTBasic
